### PR TITLE
setting cookies to work with subdomains

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2,9 +2,9 @@ portal: T2D
 log: stdout
 port: 8090
 auth:
-    google:
-        secretId: google-oauth-portal
-        callbackHost: localhost:8090
+  google:
+    secretId: google-oauth-portal
+    callbackHost: localhost.com:8090
 content:
-    dist: ""
+  dist: ""
 logins: dig-dug-logins

--- a/server.js
+++ b/server.js
@@ -1,7 +1,6 @@
 const express = require("express");
 const cookieParser = require("cookie-parser");
 const path = require("path");
-const request = require("request");
 const log4js = require("log4js");
 const google = require("./google");
 const logins = require("./logins");
@@ -48,9 +47,16 @@ function create_routes(config, app) {
 }
 
 function logOut(req, res) {
-    //clear all cookies and redirect home
-    res.clearCookie("session");
+    res.clearCookie("session", { domain: getDomain(req.hostname) });
     res.redirect("/");
+}
+
+//get domain from hostname
+function getDomain(host) {
+    let parts = host.split(".");
+    if (parts.length >= 2) {
+        return parts[parts.length - 2] + "." + parts[parts.length - 1];
+    } else return host;
 }
 
 function validateConfig(config) {
@@ -94,9 +100,7 @@ function start(config) {
     logins.connectToDatabase(config);
 
     // get metadata before starting server
-    app.listen(port, () =>
-        logger.info(`Server started on port ${port}...`)
-    );
+    app.listen(port, () => logger.info(`Server started on port ${port}...`));
 }
 
 module.exports = {


### PR DESCRIPTION
Most browser cannot access subdomains of localhost, and cookies won't work with them either. Therefore, DNS entries need to be added to the hosts file for development. 

 ```
127.0.0.1       localhost.com
127.0.0.1       md.localhost.com
127.0.0.1       t2d.localhost.com
127.0.0.1       sleep.localhost.com
127.0.0.1       cd.localhost.com
127.0.0.1       cvd.localhost.com
```